### PR TITLE
Bump function-sdk-go to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.4
 
 require (
 	github.com/alecthomas/kong v1.4.0
-	github.com/crossplane/function-sdk-go v0.5.0-rc.0.0.20250715215746-ca27889cd196
+	github.com/crossplane/function-sdk-go v0.5.0-rc.0.0.20250805171053-2910b68d255d
 	github.com/google/go-cmp v0.7.0
 	github.com/i2y/langchaingo-mcp-adapter v0.0.0-20250623114610-a01671e1c8df
 	github.com/mark3labs/mcp-go v0.37.0

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/crossplane/crossplane-runtime v1.20.0 h1:I54uipRIecqZyms+vz1J/l62yjVQ7HV5w+Nh3RMrUtc=
 github.com/crossplane/crossplane-runtime v1.20.0/go.mod h1:lfV1VJenDc9PNVLxDC80YjPoTm+JdSZ13xlS2h37Dvg=
-github.com/crossplane/function-sdk-go v0.5.0-rc.0.0.20250715215746-ca27889cd196 h1:wsaHsx3jIuJzEB+9O8+AegjfwaVM0j7IIlOegUTVtDE=
-github.com/crossplane/function-sdk-go v0.5.0-rc.0.0.20250715215746-ca27889cd196/go.mod h1:fEwSBgMH6+kicaBeOWz6PZRwhjLg4tu9QEDeP/9O2yE=
+github.com/crossplane/function-sdk-go v0.5.0-rc.0.0.20250805171053-2910b68d255d h1:bzt8qEg9I2GrLc216IuuTn4x+GECxc+DoGlDZ4PMuJY=
+github.com/crossplane/function-sdk-go v0.5.0-rc.0.0.20250805171053-2910b68d255d/go.mod h1:fEwSBgMH6+kicaBeOWz6PZRwhjLg4tu9QEDeP/9O2yE=
 github.com/crossplane/upjet v1.4.1-0.20240911184956-3afbb7796d46 h1:2IH1YPTBrNmBj0Z1OCjEBTrQCuRaLutZbWLaswFeCFQ=
 github.com/crossplane/upjet v1.4.1-0.20240911184956-3afbb7796d46/go.mod h1:wkdZf/Cvhr6PI30VdHIOjg4dX39Z5uijqnLWFk5PbGM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Adds support for https://github.com/crossplane/function-sdk-go/pull/221. Without this, function-openai is not receiving requiredResouces.

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
