### PR TITLE
config for local models, switch to NewOpenAIFunctionsAgent

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ There are a few steps to get this going.
 development.
 ```bash
 export OPENAI_API_KEY_B64=$(echo ${OPENAI_API_KEY} | base64)
+# Optional: export OPENAI_BASE_URL_B64=$(echo ${OPENAI_BASE_URL} | base64)
+# Optional: export OPENAI_MODEL_B64=$(echo ${OPENAI_MODEL} | base64)
 
 cat <<EOF | envsubst > example/secret.yaml
   apiVersion: v1
@@ -154,6 +156,12 @@ cat <<EOF | envsubst > example/secret.yaml
     namespace: crossplane-system
   data:
     OPENAI_API_KEY: ${OPENAI_API_KEY_B64}
+    # OPENAI_BASE_URL: ${OPENAI_BASE_URL_B64}
+    # Optional: Use custom OpenAI-compatible endpoint
+    # Example: http://localhost:11434/v1
+    # OPENAI_MODEL: ${OPENAI_MODEL_B64}
+    # Optional: Use custom model (defaults to gpt-4)
+    # Example: gpt-oss:20b
 EOF
 ```
 

--- a/fn.go
+++ b/fn.go
@@ -44,11 +44,11 @@ import (
 )
 
 const (
-	credName        = "gpt"
-	credKey         = "OPENAI_API_KEY"
-	credBaseURLKey  = "OPENAI_BASE_URL"
-	credModelKey    = "OPENAI_MODEL"
-	defaultModel    = "gpt-4"
+	credName       = "gpt"
+	credKey        = "OPENAI_API_KEY"
+	credBaseURLKey = "OPENAI_BASE_URL"
+	credModelKey   = "OPENAI_MODEL"
+	defaultModel   = "gpt-4"
 )
 
 // Variables used to form the prompt.

--- a/fn_test.go
+++ b/fn_test.go
@@ -117,7 +117,7 @@ func TestRunFunction(t *testing.T) {
 			reason: "We should go through the composition pipeline without error.",
 			args: args{
 				ai: &mockAgentInvoker{
-					InvokeFn: func(_ context.Context, _, _, _ string) (string, error) {
+					InvokeFn: func(_ context.Context, _, _, _, _, _ string) (string, error) {
 						return `---
 apiVersion: some.group/v1
 metadata:
@@ -200,7 +200,7 @@ metadata:
 			reason: "We should go through the operation pipeline without error.",
 			args: args{
 				ai: &mockAgentInvoker{
-					InvokeFn: func(_ context.Context, _, _, _ string) (string, error) {
+					InvokeFn: func(_ context.Context, _, _, _, _, _ string) (string, error) {
 						return `some-response`, nil
 					},
 				},
@@ -281,9 +281,9 @@ func mockCredentials() map[string]*fnv1.Credentials {
 }
 
 type mockAgentInvoker struct {
-	InvokeFn func(ctx context.Context, key, system, prompt string) (string, error)
+	InvokeFn func(ctx context.Context, key, system, prompt, baseURL, modelName string) (string, error)
 }
 
-func (m *mockAgentInvoker) Invoke(ctx context.Context, key, system, prompt string) (string, error) {
-	return m.InvokeFn(ctx, key, system, prompt)
+func (m *mockAgentInvoker) Invoke(ctx context.Context, key, system, prompt, baseURL, modelName string) (string, error) {
+	return m.InvokeFn(ctx, key, system, prompt, baseURL, modelName)
 }


### PR DESCRIPTION
### Description of your changes

Adding configuration ability for local models conforming to OpenAI API standards. Switched to agents.NewOpenAIFunctionsAgent() instead of agents.NewOneShotAgent() to help handle parsing output. 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
